### PR TITLE
Fix to remove debug javascript comments

### DIFF
--- a/toolkit/javascripts/module-loader.js
+++ b/toolkit/javascripts/module-loader.js
@@ -13,7 +13,7 @@
   }
 
   if (
-    (GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine)
+    (GDM.debug = !window.location.href.match(/gov.au/) && !window.jasmine)
   ) {
     console.log(
       "%cDebug mode %cON",


### PR DESCRIPTION
Change .gov.uk. to .gov.au
